### PR TITLE
🔧 Enhance date input styling for mobile and desktop responsiveness

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -197,17 +197,61 @@ body {
   box-sizing: border-box;
 }
 
-.form-input[type="date"]::-webkit-calendar-picker-indicator {
-  background: transparent;
-  bottom: 0;
-  color: transparent;
-  cursor: pointer;
-  height: auto;
-  left: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
-  width: auto;
+/* Desktop date picker styling */
+@media (min-width: 769px) {
+  .form-input[type="date"]::-webkit-calendar-picker-indicator {
+    background: transparent;
+    bottom: 0;
+    color: transparent;
+    cursor: pointer;
+    height: auto;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: auto;
+  }
+}
+
+/* Mobile date picker styling - restore native behavior */
+@media (max-width: 768px) {
+  .form-input[type="date"] {
+    height: 3.5rem;
+    padding: 1rem;
+    font-size: 16px; /* Prevent zoom on iOS */
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-primary);
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+  }
+  
+  .form-input[type="date"]::-webkit-calendar-picker-indicator {
+    opacity: 1;
+    background: none;
+    color: var(--accent-blue);
+    cursor: pointer;
+    position: static;
+    width: 20px;
+    height: 20px;
+    margin-left: auto;
+    filter: invert(1);
+  }
+  
+  .form-input[type="date"]:focus {
+    outline: none;
+    border-color: var(--accent-blue);
+    box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.1);
+    background: var(--bg-quaternary);
+  }
+  
+  /* Enhance touch target for mobile */
+  .form-input[type="date"] {
+    min-height: 44px;
+    touch-action: manipulation;
+  }
 }
 
 /* Modern Button */


### PR DESCRIPTION
This pull request updates the styling of date picker inputs to provide a better user experience on both desktop and mobile devices. The changes introduce responsive CSS rules to ensure the date picker is visually consistent and user-friendly across different screen sizes.

**Responsive date picker styling:**

* Added a media query for desktop (`min-width: 769px`) to apply custom styles to the `.form-input[type="date"]::-webkit-calendar-picker-indicator` for improved appearance on larger screens.
* Added a media query for mobile (`max-width: 768px`) to restore native date picker behavior and enhance usability, including increased input height, padding, font size adjustments to prevent iOS zoom, and improved touch targets. Also customized the appearance of the calendar picker indicator and focus state for better accessibility and visual feedback.